### PR TITLE
feat:list update

### DIFF
--- a/client/lib/main.dart
+++ b/client/lib/main.dart
@@ -1,3 +1,4 @@
+
 import 'package:client/common/const/app_colors.dart';
 import 'package:client/data/provider/room_data_provider.dart';
 import 'package:client/ui/view/create_room_screen.dart';

--- a/client/lib/ui/view/game/dudeoji_game_screen.dart
+++ b/client/lib/ui/view/game/dudeoji_game_screen.dart
@@ -88,7 +88,7 @@ class _DudeojiGameScreenState extends State<DudeojiGameScreen> {
       context: context,
       builder: (BuildContext context) {
         return AlertDialog(
-          title: Text('게임 종료'),
+          title: const Text('게임 종료'),
           content: Text('점수: $score'),
           actions: [
             TextButton(
@@ -101,11 +101,11 @@ class _DudeojiGameScreenState extends State<DudeojiGameScreen> {
                     .then((_) {
                   Navigator.of(context).push(MaterialPageRoute(
                     builder: (context) =>
-                        const DudeojiGameScreen(title: '두더지 잡기'),
+                        const DudeojiGameScreen(title: '두더지 팡팡'),
                   ));
                 });
               },
-              child: Text('확인'),
+              child: const Text('확인'),
             ),
           ],
         );
@@ -173,86 +173,86 @@ class _DudeojiGameScreenState extends State<DudeojiGameScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: AppColors.bgColor,
-      body: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          const Text(
-            'Whack a Mole',
-            style: TextStyle(
-              color: Colors.white,
-              fontSize: 40,
-              backgroundColor: Colors.orange,
-            ),
-          ),
-          const SizedBox(height: 40),
-          Container(
-            padding: const EdgeInsets.all(8),
-            decoration: BoxDecoration(
-              border: Border.all(
-                color: Colors.orange,
-                width: 4,
+    return WillPopScope(
+      onWillPop: () async => false, // 뒤로가기 버튼 비활성화
+      child: Scaffold(
+        backgroundColor: AppColors.bgColor,
+        appBar: AppBar(
+          title: const Text('두더지 팡팡'),
+          automaticallyImplyLeading: false, // 뒤로가기 버튼 숨기기
+          backgroundColor: AppColors.bgColor,
+        ),
+        body: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            const SizedBox(height: 40),
+            Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                border: Border.all(
+                  color: Colors.orange,
+                  width: 4,
+                ),
+                borderRadius: const BorderRadius.all(Radius.circular(20)),
               ),
-              borderRadius: const BorderRadius.all(Radius.circular(20)),
-            ),
-            child: Text(
-              'Score: $score',
-              style: const TextStyle(
-                fontSize: 24,
-                color: Colors.white,
+              child: Text(
+                'Score: $score',
+                style: const TextStyle(
+                  fontSize: 24,
+                  color: Colors.white,
+                ),
               ),
             ),
-          ),
-          const SizedBox(height: 20),
-          Expanded(
-            child: GridView.count(
-              crossAxisCount: columns,
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              children: buildGridItems(),
+            const SizedBox(height: 20),
+            Expanded(
+              child: GridView.count(
+                crossAxisCount: columns,
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                children: buildGridItems(),
+              ),
             ),
-          ),
-          const SizedBox(height: 20),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 32.0), // 좌우 패딩 추가
-            child: TweenAnimationBuilder(
-              tween: Tween<double>(begin: 0, end: progress),
-              duration:
-                  const Duration(seconds: 1), // 부드러운 진행을 위해 애니메이션 지속 시간 조절
-              builder: (context, value, child) {
-                return Stack(
-                  children: [
-                    Container(
-                      width: double.infinity,
-                      height: 30,
-                      decoration: BoxDecoration(
-                        color: Colors.grey,
-                        borderRadius: BorderRadius.circular(10),
+            const SizedBox(height: 20),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 32.0), // 좌우 패딩 추가
+              child: TweenAnimationBuilder(
+                tween: Tween<double>(begin: 0, end: progress),
+                duration:
+                    const Duration(seconds: 1), // 부드러운 진행을 위해 애니메이션 지속 시간 조절
+                builder: (context, value, child) {
+                  return Stack(
+                    children: [
+                      Container(
+                        width: double.infinity,
+                        height: 30,
+                        decoration: BoxDecoration(
+                          color: Colors.grey,
+                          borderRadius: BorderRadius.circular(10),
+                        ),
                       ),
-                    ),
-                    Container(
-                      width: MediaQuery.of(context).size.width * value,
-                      height: 30,
-                      decoration: BoxDecoration(
-                        color: Colors.orange,
-                        borderRadius: BorderRadius.circular(10),
+                      Container(
+                        width: MediaQuery.of(context).size.width * value,
+                        height: 30,
+                        decoration: BoxDecoration(
+                          color: Colors.orange,
+                          borderRadius: BorderRadius.circular(10),
+                        ),
                       ),
-                    ),
-                    Center(
-                      child: Text(
-                        '00:${_timeRemaining.toString().padLeft(2, '0')}',
-                        style: TextStyle(color: Colors.black, fontSize: 20),
+                      Center(
+                        child: Text(
+                          '00:${_timeRemaining.toString().padLeft(2, '0')}',
+                          style: const TextStyle(color: Colors.black, fontSize: 20),
+                        ),
                       ),
-                    ),
-                  ],
-                );
-              },
+                    ],
+                  );
+                },
+              ),
             ),
-          ),
-          const SizedBox(height: 20),
-        ],
+            const SizedBox(height: 20),
+          ],
+        ),
       ),
     );
   }
@@ -272,249 +272,10 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Whack a Mole Game',
       debugShowCheckedModeBanner: false,
-      home: DudeojiGameScreen(title: 'Whack a Mole'),
+      home: DudeojiGameScreen(title: '두더지 팡팡'),
       routes: {
         GameListScreen.routeName: (context) => const GameListScreen(), // 경로 설정
       },
     );
   }
 }
-// import 'dart:async';
-// import 'dart:math';
-// import 'package:client/common/const/app_colors.dart';
-// import 'package:client/ui/view/game_list_screen.dart';
-// import 'package:flutter/material.dart';
-
-// class DudeojiGameScreen extends StatefulWidget {
-//   final String title;
-//   const DudeojiGameScreen({super.key, required this.title});
-
-//   @override
-//   State<DudeojiGameScreen> createState() => _DudeojiGameScreenState();
-// }
-
-// class _DudeojiGameScreenState extends State<DudeojiGameScreen> {
-//   final int rows = 3;
-//   final int columns = 4;
-//   final int gameTime = 20;
-//   List<bool> moles = [];
-//   int score = 0;
-//   late Timer _timer;
-//   int _timeRemaining = 20;
-//   double progress = 0.0;
-
-//   @override
-//   void initState() {
-//     super.initState();
-//     startGame();
-//   }
-
-//   void startGame() {
-//     score = 0;
-//     moles = List.filled(rows * columns, false);
-//     _timeRemaining = gameTime;
-//     progress = 0.0;
-
-//     Timer.periodic(const Duration(seconds: 1), (timer) {
-//       if (_timeRemaining <= 0) {
-//         timer.cancel();
-//       } else if (mounted) {
-//         setState(() {
-//           final random = Random();
-//           final index = random.nextInt(rows * columns);
-//           moles[index] = !moles[index];
-//           if (moles[index]) {
-//             Timer(const Duration(milliseconds: 500), () {
-//               if (mounted) {
-//                 setState(() {
-//                   moles[index] = false;
-//                 });
-//               }
-//             });
-//           }
-//         });
-//       }
-//     });
-
-//     _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
-//       setState(() {
-//         _timeRemaining--;
-//         progress = 1 - (_timeRemaining / gameTime);
-//       });
-//       if (_timeRemaining <= 0) {
-//         timer.cancel();
-//         endGame();
-//       }
-//     });
-//   }
-
-//   void endGame() {
-//     showDialog(
-//       context: context,
-//       builder: (BuildContext context) {
-//         return AlertDialog(
-//           title: Text('게임 종료'),
-//           content: Text('점수: $score'),
-//           actions: [
-//             TextButton(
-//               onPressed: () {
-//                 Navigator.of(context).pushNamedAndRemoveUntil(
-//                   GameListScreen.routeName,
-//                   (Route<dynamic> route) => false,
-//                 ).then((_) {
-//                   Navigator.of(context).push(MaterialPageRoute(
-//                     builder: (context) => const DudeojiGameScreen(title: '두더지 잡기'),
-//                   ));
-//                 });
-//               },
-//               child: Text('확인'),
-//             ),
-//           ],
-//         );
-//       },
-//     );
-//   }
-
-//   void onTapMole(int index) {
-//     if (moles[index]) {
-//       setState(() {
-//         moles[index] = false;
-//         score++;
-//       });
-//     }
-//   }
-
-//   List<Widget> buildGridItems() {
-//     List<Widget> items = [];
-//     for (int i = 0; i < rows * columns; i++) {
-//       items.add(
-//         GestureDetector(
-//           onTap: () => onTapMole(i),
-//           child: Container(
-//             margin: const EdgeInsets.all(4),
-//             decoration: const BoxDecoration(
-//               image: DecorationImage(image: AssetImage('asset/land.png')),
-//             ),
-//             child: Center(
-//               child: Padding(
-//                 padding: const EdgeInsets.only(bottom: 32),
-//                 child: moles[i]
-//                     ? Image.asset(
-//                         'asset/mole.png',
-//                         height: 80,
-//                         width: 80,
-//                       )
-//                     : null,
-//               ),
-//             ),
-//           ),
-//         ),
-//       );
-//     }
-//     return items;
-//   }
-
-//   @override
-//   Widget build(BuildContext context) {
-//     return Scaffold(
-//       backgroundColor: AppColors.bgColor,
-//       body: Column(
-//         mainAxisAlignment: MainAxisAlignment.center,
-//         crossAxisAlignment: CrossAxisAlignment.center,
-//         children: [
-//           const Text(
-//             'Whack a Mole',
-//             style: TextStyle(
-//               color: Colors.white,
-//               fontSize: 40,
-//               backgroundColor: Colors.orange,
-//             ),
-//           ),
-//           const SizedBox(height: 40),
-//           Container(
-//             padding: const EdgeInsets.all(8),
-//             decoration: BoxDecoration(
-//               border: Border.all(
-//                 color: Colors.orange,
-//                 width: 4,
-//               ),
-//               borderRadius: const BorderRadius.all(Radius.circular(20)),
-//             ),
-//             child: Text(
-//               'Score: $score',
-//               style: const TextStyle(
-//                 fontSize: 24,
-//                 color: Colors.white,
-//               ),
-//             ),
-//           ),
-//           const SizedBox(height: 20),
-//           Expanded(
-//             child: GridView.count(
-//               crossAxisCount: columns,
-//               shrinkWrap: true,
-//               physics: const NeverScrollableScrollPhysics(),
-//               children: buildGridItems(),
-//             ),
-//           ),
-//           const SizedBox(height: 20),
-//           Padding(
-//             padding: const EdgeInsets.symmetric(horizontal: 16.0),
-//             child: TweenAnimationBuilder(
-//               tween: Tween<double>(begin: 0, end: progress),
-//               duration: const Duration(seconds: 1), // 부드러운 진행을 위해 애니메이션 지속 시간 조절
-//               builder: (context, value, child) {
-//                 return Stack(
-//                   children: [
-//                     Container(
-//                       width: double.infinity,
-//                       height: 30,
-//                       decoration: BoxDecoration(
-//                         color: Colors.grey,
-//                         borderRadius: BorderRadius.circular(10),
-//                       ),
-//                     ),
-//                     Container(
-//                       width: MediaQuery.of(context).size.width * value,
-//                       height: 30,
-//                       decoration: BoxDecoration(
-//                         color: Colors.orange,
-//                         borderRadius: BorderRadius.circular(10),
-//                       ),
-//                     ),
-//                     Center(
-//                       child: Text(
-//                         '00:${_timeRemaining.toString().padLeft(2, '0')}',
-//                         style: TextStyle(color: Colors.black, fontSize: 20),
-//                       ),
-//                     ),
-//                   ],
-//                 );
-//               },
-//             ),
-//           ),
-//           const SizedBox(height: 20),
-//         ],
-//       ),
-//     );
-//   }
-// }
-
-// // 앱의 진입점
-// void main() {
-//   runApp(const MyApp());
-// }
-
-// // 메인 앱 클래스
-// class MyApp extends StatelessWidget {
-//   const MyApp({super.key});
-
-//   @override
-//   Widget build(BuildContext context) {
-//     return MaterialApp(
-//       title: 'Whack a Mole Game',
-//       debugShowCheckedModeBanner: false,
-//       home: DudeojiGameScreen(title: 'Whack a Mole'),
-//     );
-//   }
-// }

--- a/client/lib/ui/view/game_list_request.dart
+++ b/client/lib/ui/view/game_list_request.dart
@@ -1,0 +1,1 @@
+// TODO Implement this library.

--- a/client/lib/ui/view/game_list_screen.dart
+++ b/client/lib/ui/view/game_list_screen.dart
@@ -1,7 +1,10 @@
-
+import 'dart:convert';
 import 'package:client/common/widgets/game_list_tile.dart';
+import 'package:client/data/models/game_list_request.dart';
 import 'package:client/ui/view/game_wait_screen.dart';
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'game_list_request.dart';
 
 class GameListScreen extends StatefulWidget {
   static String routeName = '/game-list';
@@ -12,13 +15,29 @@ class GameListScreen extends StatefulWidget {
 }
 
 class _GameListScreenState extends State<GameListScreen> {
-  // TODO: Get data from Server
-  final List<Map<String, String>> games = [
-    {'title': '두더지 팡팡', 'subtitle': '최대한 빠르게 두더지를 때려봅시다!', 'id': '1'},
-    {'title': '닮은 사람 찾기', 'subtitle': '가장 닮은 사람 둘 마셔!', 'id': '2'},
-    {'title': '라이어 게임', 'subtitle': '누구인가.. 누가 라이어소리를 내었어...', 'id': '3'},
-    {'title': '훈민정음', 'subtitle': '한국어 좀 치는 분들 모이세요', 'id': '4'},
-  ];
+  List<GameListRequest> games = [];
+  bool isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    fetchGames();
+  }
+
+  Future<void> fetchGames() async {
+    const url = 'http://143.248.191.30:3000/games';
+    final response = await http.get(Uri.parse(url));
+
+    if (response.statusCode == 200) {
+      final List<dynamic> jsonResponse = json.decode(response.body)['result'];
+      setState(() {
+        games = jsonResponse.map((data) => GameListRequest.fromJson(data)).toList();
+        isLoading = false;
+      });
+    } else {
+      throw Exception('Failed to load games');
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -32,33 +51,34 @@ class _GameListScreenState extends State<GameListScreen> {
         ),
         title: const Text('게임 선택'),
       ),
-      body: Container(
-        margin: const EdgeInsets.all(20),
-        child: ListView.builder(
-          itemCount: games.length,
-          itemBuilder: (context, index) {
-            return GameListTile(
-              title: games[index]['title']!,
-              subtitle: games[index]['subtitle']!,
-              onTap: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => GameWaitScreen(
-                      title: games[index]['title']!,
-                      gameId: games[index]['id']!,
-                    ),
-                  ),
-                );
-              },
-            );
-          },
-        ),
-      ),
+      body: isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : Container(
+              margin: const EdgeInsets.all(20),
+              child: ListView.builder(
+                itemCount: games.length,
+                itemBuilder: (context, index) {
+                  return GameListTile(
+                    title: games[index].name,
+                    subtitle: games[index].description,
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => GameWaitScreen(
+                            title: games[index].name,
+                            gameId: games[index].gameId,
+                          ),
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
     );
   }
 }
-
 // import 'package:client/common/widgets/game_list_tile.dart';
 // import 'package:client/ui/view/game_wait_screen.dart';
 // import 'package:flutter/material.dart';
@@ -74,8 +94,8 @@ class _GameListScreenState extends State<GameListScreen> {
 // class _GameListScreenState extends State<GameListScreen> {
 //   // TODO: Get data from Server
 //   final List<Map<String, String>> games = [
-//     {'title': '두더지 팡팡', 'subtitle': '최대한 빠르게 두더지를 때려봅시다!', 'id': '668c2506bfaa70b1e661ce11'},
-//     {'title': '닮은 사람 찾기', 'subtitle': '가장 닮은 사람 둘 마셔!', 'id': '668c2506bfaa70b1e661ce12'},
+//     {'title': '두더지 팡팡', 'subtitle': '최대한 빠르게 두더지를 때려봅시다!', 'id': '1'},
+//     {'title': '닮은 사람 찾기', 'subtitle': '가장 닮은 사람 둘 마셔!', 'id': '2'},
 //     {'title': '라이어 게임', 'subtitle': '누구인가.. 누가 라이어소리를 내었어...', 'id': '3'},
 //     {'title': '훈민정음', 'subtitle': '한국어 좀 치는 분들 모이세요', 'id': '4'},
 //   ];


### PR DESCRIPTION
list screen 어제껄로 복구

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 게임 목록 화면에서 서버로부터 게임 데이터를 가져와 UI를 업데이트하는 기능 추가.

- **수정된 사항**
  - '게임 종료' 알림창의 제목 및 버튼 텍스트가 상수로 변경.
  - 앱 바 제목이 '두더지 팡팡'으로 변경.
  - 게임 목록 화면에서 게임 데이터를 가져오는 동안 로딩 인디케이터 표시.
  
- **기타**
  - 게임 목록 요청 실행을 위한 자리 표시자 주석 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->